### PR TITLE
Fix exit artifacts and Dockerfile build args; add optional commit pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+execution_agent_workspace/
+search_logs/
+search_logs_unified/
+__pycache__/
+
+# macOS
+.DS_Store

--- a/launcher.py
+++ b/launcher.py
@@ -42,6 +42,7 @@ class Project:
     url: str
     language: str
     image_tag: str
+    commit: str = ""          # commit SHA to check out; empty means default branch HEAD
 
     @property
     def safe_name(self) -> str:
@@ -139,6 +140,7 @@ def create_metadata_file(project: Project, output_dir: Path, budget: int = 40) -
         "project_url": project.url,
         "language": project.language,
         "image_tag": project.image_tag,
+        "commit": project.commit,           # checked out by the agent; empty = HEAD
         "budget": budget,                   # Step limit per attempt
         "created_at": datetime.now().isoformat(),
     }

--- a/launcher.py
+++ b/launcher.py
@@ -226,6 +226,7 @@ class AgentRunner:
         self,
         workspace_root: Path,
         model: str = "gpt-4o-mini",
+        knowledge_model: Optional[str] = None,
         step_limit: int = 40,
         max_retries: int = 2,
         parallel: int = 1,
@@ -234,6 +235,7 @@ class AgentRunner:
     ):
         self.workspace_root = workspace_root
         self.model = model
+        self.knowledge_model = knowledge_model
         self.step_limit = step_limit
         self.max_retries = max_retries
         self.parallel = parallel
@@ -282,6 +284,8 @@ class AgentRunner:
             "--model", self.model,
             "--max-retries", str(self.max_retries),
         ]
+        if self.knowledge_model:
+            cmd += ["--knowledge-model", self.knowledge_model]
 
         print(f"\n{'=' * 60}")
         print(f"Starting: {project.name} ({project.language})")
@@ -502,6 +506,12 @@ Examples:
         help="Model to use (default: gpt-4o-mini)",
     )
     parser.add_argument(
+        "--knowledge-model",
+        type=str,
+        default=None,
+        help="Knowledge model for web search/summaries (passed through to the agent)",
+    )
+    parser.add_argument(
         "--step-limit", "-s",
         type=int,
         default=40,
@@ -609,6 +619,7 @@ def main() -> int:
         runner = AgentRunner(
             workspace_root=workspace_root,
             model=args.model,
+            knowledge_model=args.knowledge_model,
             step_limit=args.step_limit,
             max_retries=args.max_retries,
             parallel=args.parallel,

--- a/src/execution_agent/agent.py
+++ b/src/execution_agent/agent.py
@@ -320,6 +320,23 @@ class ExecutionAgent:
             parts.append(f"Project path: {ctx.project_path}")
             parts.append(f"Project URL: {ctx.project_url}")
             parts.append(f"Primary language: {ctx.language}")
+
+            pinned = getattr(ctx, "commit", None) or getattr(self, "commit", "")
+            if pinned:
+                parts.append("")
+                parts.append(f"REQUIRED COMMIT: {pinned}")
+                parts.append(
+                    "This task targets that exact commit, not the default branch. Your Dockerfile "
+                    "must clone with full history and check it out, e.g.:\n"
+                    "```dockerfile\n"
+                    "ARG REPO_URL\n"
+                    f"ARG COMMIT_SHA={pinned}\n"
+                    'RUN git clone "$REPO_URL" repo && cd repo && git checkout --detach "$COMMIT_SHA"\n'
+                    "```\n"
+                    "Do NOT use `git clone --depth 1` alone - a shallow clone of the default branch "
+                    "will not contain this commit. Verify with `git rev-parse HEAD` before running "
+                    "the tests, and build/test the code at this commit."
+                )
             parts.append("")
 
             # Add language-specific guidelines if available

--- a/src/execution_agent/context.py
+++ b/src/execution_agent/context.py
@@ -352,6 +352,7 @@ class RepoContext:
     unified_summary: Optional[str] = None
     problems_memory: Optional[str] = None
     local_repo_available: bool = False                # True if repo was cloned locally during preprocessing
+    commit: Optional[str] = None                      # pinned commit SHA, if any
 
     def __post_init__(self):
         if self.requirement_files is None:
@@ -869,34 +870,54 @@ class ContextBuilder:
         return txt if txt.strip() else None
 
     # ---------- repository cloning ----------
-    def clone_repo(self, project_path: str, project_url: str) -> bool:
+    def clone_repo(self, project_path: str, project_url: str, commit: str = "") -> bool:
         """
         Clone the repository into workspace_root/project_path if not already present.
-        Returns True if the repo is available (either already existed or was cloned successfully).
+
+        When `commit` is set the clone is made at full depth and checked out at that
+        SHA, so one repository can appear under several project_path directories
+        pinned to different commits. Without a commit the clone stays shallow.
+
+        Returns True if the repo is available and, when requested, sits at `commit`.
         """
         target_dir = os.path.join(self.workspace_root, project_path)
+
+        def _checkout(where: str) -> bool:
+            if not commit:
+                return True
+            res = subprocess.run(
+                ["git", "-C", where, "checkout", "--detach", commit],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=300,
+            )
+            if res.returncode == 0:
+                _LOG.info(f"Checked out {commit} in {where}")
+                return True
+            _LOG.warning(f"Failed to check out {commit} in {where}: {res.stderr.strip()}")
+            return False
 
         # Check if already cloned (has .git directory)
         if os.path.isdir(os.path.join(target_dir, ".git")):
             _LOG.info(f"Repository already exists at {target_dir}")
-            return True
+            return _checkout(target_dir)
 
         # Create parent directory if needed
         os.makedirs(self.workspace_root, exist_ok=True)
 
         # Clone the repository
-        _LOG.info(f"Cloning repository {project_url} to {target_dir}...")
+        cmd = ["git", "clone"] + ([] if commit else ["--depth", "1"]) + [project_url, target_dir]
+        _LOG.info(f"Cloning repository {project_url} to {target_dir}"
+                  + (f" (full depth, will check out {commit})" if commit else " (shallow)") + "...")
         try:
             result = subprocess.run(
-                ["git", "clone", "--depth", "1", project_url, target_dir],
+                cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                timeout=300,  # 5 minute timeout for large repos
+                timeout=900 if commit else 300,  # full clones of large repos are slow
             )
             if result.returncode == 0:
                 _LOG.info(f"Successfully cloned {project_url} to {target_dir}")
-                return True
+                return _checkout(target_dir)
             else:
                 _LOG.warning(f"Failed to clone {project_url}: {result.stderr}")
                 return False
@@ -1469,6 +1490,7 @@ Provide a concise, actionable summary focused on our goal of installing from sou
         project_url: str,
         language: str,
         search_workflows_summary_prompt: str,
+        commit: str = "",
         unified_summary_cache_root: str = "search_logs_unified",
         perform_web_search_if_missing: bool = True,
     ) -> RepoContext:
@@ -1490,7 +1512,7 @@ Provide a concise, actionable summary focused on our goal of installing from sou
             perform_web_search_if_missing: Whether to perform web search if no cached results
         """
         # Clone the repository first so the agent can explore it before creating a container
-        local_repo_available = self.clone_repo(project_path, project_url)
+        local_repo_available = self.clone_repo(project_path, project_url, commit=commit)
 
         # Find and load workflow files (CI/CD)
         workflows = self.find_workflows(project_path, filter_by_keywords=False)
@@ -1566,4 +1588,5 @@ Provide a concise, actionable summary focused on our goal of installing from sou
             unified_summary=unified_summary,
             problems_memory=problems_memory,
             local_repo_available=local_repo_available,
+            commit=commit or None,
         )

--- a/src/execution_agent/exit_artifacts.py
+++ b/src/execution_agent/exit_artifacts.py
@@ -27,21 +27,25 @@ def _escape_bash_string(s: str) -> str:
 
 def _extract_dockerfile_content(agent: Any) -> Optional[str]:
     """
-    Extract the Dockerfile content from the agent's written_files.
+    Extract the Dockerfile content from the agent.
+
+    Prefers agent.base_dockerfile, which is only set once a Dockerfile has
+    successfully built an image and started a container. Falls back to the most
+    recently written Dockerfile, since earlier ones may have failed to build.
 
     Returns:
         The Dockerfile content if found, None otherwise.
     """
+    # Prefer the Dockerfile that actually built and started a container
+    if getattr(agent, "base_dockerfile", None):
+        return agent.base_dockerfile
+
     written_files = getattr(agent, "written_files", [])
 
-    for target_name, location, actual_path, content in written_files:
+    for target_name, location, actual_path, content in reversed(written_files):
         # Check if this is a Dockerfile
         if target_name.lower() == "dockerfile" or target_name.lower().endswith(".dockerfile"):
             return content
-
-    # Also check if stored directly on agent
-    if hasattr(agent, "base_dockerfile") and agent.base_dockerfile:
-        return agent.base_dockerfile
 
     return None
 

--- a/src/execution_agent/exit_artifacts.py
+++ b/src/execution_agent/exit_artifacts.py
@@ -121,6 +121,7 @@ def _generate_launch_script(
     commands_script_path: str,
     project_path: str,
     docker_tag: str = "",
+    project_url: str = "",
 ) -> str:
     """
     Generate a launch.sh script that builds the Docker image and runs the commands.
@@ -130,6 +131,8 @@ def _generate_launch_script(
         commands_script_path: Path to the commands script (relative to launch.sh)
         project_path: The project path for context
         docker_tag: Optional custom docker tag
+        project_url: Repository URL, passed as the REPO_URL build arg to mirror the
+            agent's own build (generated Dockerfiles often declare `ARG REPO_URL`)
 
     Returns:
         Launch script content
@@ -173,6 +176,8 @@ def _generate_launch_script(
     lines.append("")
     lines.append("# Configuration")
     lines.append(f"DOCKER_TAG='{_escape_bash_string(tag)}'")
+    if project_url:
+        lines.append(f"REPO_URL='{_escape_bash_string(project_url)}'")
     lines.append(f'DOCKERFILE_PATH="$SCRIPT_DIR/{dockerfile_path}"')
     lines.append(f'COMMANDS_SCRIPT="$SCRIPT_DIR/{commands_script_path}"')
     lines.append('CONTAINER_ID=""')
@@ -200,7 +205,12 @@ def _generate_launch_script(
     lines.append("echo ''")
     lines.append("")
     lines.append('DOCKERFILE_DIR="$(dirname "$DOCKERFILE_PATH")"')
-    lines.append('docker build -t "$DOCKER_TAG" "$DOCKERFILE_DIR"')
+    if project_url:
+        # Harmless if the Dockerfile hardcodes the URL: docker only warns about
+        # build args it does not declare.
+        lines.append('docker build --build-arg REPO_URL="$REPO_URL" -t "$DOCKER_TAG" "$DOCKERFILE_DIR"')
+    else:
+        lines.append('docker build -t "$DOCKER_TAG" "$DOCKERFILE_DIR"')
     lines.append("")
     lines.append("BUILD_STATUS=$?")
     lines.append("if [ $BUILD_STATUS -ne 0 ]; then")
@@ -323,6 +333,7 @@ def generate_exit_artifacts(
         commands_script_path="commands.sh",
         project_path=project_path,
         docker_tag=docker_tag,
+        project_url=str(getattr(agent, "project_url", "") or ""),
     )
     launch_path = artifacts_dir / "launch.sh"
     launch_path.write_text(launch_script, encoding="utf-8")

--- a/src/execution_agent/main.py
+++ b/src/execution_agent/main.py
@@ -805,6 +805,7 @@ def main() -> int:
     project_path = meta["project_path"]
     project_url = meta["project_url"]
     language = meta.get("language", "unknown")
+    commit = str(meta.get("commit", "") or "")
 
     # Run directory for logs/transcripts
     if args.run_log_dir:
@@ -839,6 +840,8 @@ def main() -> int:
 
     LOG.info("Project: %s", project_path)
     LOG.info("Repo:    %s", project_url)
+    if commit:
+        LOG.info("Commit:  %s", commit)
     LOG.info("Model:   %s", args.model)
     LOG.info("Knowledge Model: %s", args.knowledge_model)
     LOG.info("Run dir: %s", str(run_dir))
@@ -897,6 +900,7 @@ def main() -> int:
         project_url=project_url,
         language=language,
         search_workflows_summary_prompt=search_workflows_summary,
+        commit=commit,
     )
     LOG.info("Repository context built successfully")
 
@@ -945,6 +949,7 @@ def main() -> int:
     agent.workspace_path = args.workspace_root
     agent.project_path = project_path
     agent.project_url = project_url
+    agent.commit = commit
     agent.hyperparams = meta
     agent.repo_context = repo_context
     agent.tools_doc_string = tools_doc_string

--- a/src/execution_agent/tools.py
+++ b/src/execution_agent/tools.py
@@ -1097,14 +1097,19 @@ def read_file(file_path: str, agent) -> dict[str, Any]:
 from datetime import datetime as _dt
 
 
-def _docker_build_image(dockerfile_dir: str, tag: str) -> tuple[bool, str]:
+def _docker_build_image(dockerfile_dir: str, tag: str, repo_url: str = "") -> tuple[bool, str]:
     """
     Build an image and return (ok, full_build_log_text).
 
     Keeps rich legacy logging, including docker daemon error messages, so failures
     contain actionable feedback.
+
+    If repo_url is given it is passed as the REPO_URL build arg, since generated
+    Dockerfiles commonly declare `ARG REPO_URL` and clone from it. Docker only warns
+    about build args the Dockerfile does not declare, so this is safe either way.
     """
     client = _docker_client()
+    build_args = {"REPO_URL": repo_url} if repo_url else {}
 
     def _ts() -> str:
         return _dt.now().strftime("%H:%M:%S")
@@ -1115,7 +1120,7 @@ def _docker_build_image(dockerfile_dir: str, tag: str) -> tuple[bool, str]:
         for ln in (msg.rstrip("\n").splitlines() or [""]):
             log_lines.append(f"[{_ts()}] {ln}")
 
-    _log(f"Starting build: context='{dockerfile_dir}', tag='{tag}'")
+    _log(f"Starting build: context='{dockerfile_dir}', tag='{tag}', build_args={build_args}")
 
     try:
         # Build the image - Docker SDK returns (image, logs_generator) tuple
@@ -1125,7 +1130,8 @@ def _docker_build_image(dockerfile_dir: str, tag: str) -> tuple[bool, str]:
             tag=tag,
             rm=True,
             pull=True,
-            nocache=False
+            nocache=False,
+            buildargs=build_args,
         )
 
         for chunk in logs:
@@ -1350,7 +1356,9 @@ def write_to_file(
                 # Store the docker tag for trace generation
                 agent.docker_tag = tag
 
-                ok, build_log = _docker_build_image(str(dockerfile_dir), tag)
+                ok, build_log = _docker_build_image(
+                    str(dockerfile_dir), tag, repo_url=str(getattr(agent, "project_url", "") or "")
+                )
                 if not ok:
                     # Return the FULL build log to the LLM for complete context
                     # The LLM can analyze the entire log to understand what went wrong


### PR DESCRIPTION
Four independent changes, found while running ExecutionAgent over ~110 project setups. Two are bug fixes affecting the artifacts every successful run produces, one is a new optional capability, one is a small launcher convenience. They can be taken separately if you'd prefer only some.

### 1. Use the Dockerfile that actually built for exit artifacts

`_extract_dockerfile_content` returned the **first** Dockerfile in `written_files`, but `write_to_file` appends to that list *before* attempting the build, so Dockerfiles that failed to build are recorded there too. Whenever the agent needed more than one attempt, `success_artifacts/` captured a Dockerfile that does not build.

Now prefers `agent.base_dockerfile` (assigned only after an image builds and its container starts), falling back to the most recently written Dockerfile.

*Observed:* on a run where the agent went through 8 failed builds before succeeding, the saved artifact was the cycle-1 Dockerfile and `./launch.sh` failed on it.

### 2. Pass `REPO_URL` as a build arg when building generated Dockerfiles

The Dockerfile template in the `search_workflows_summary` prompt instructs the agent to declare `ARG REPO_URL` and clone from it, but nothing ever supplied the build arg. The clone then ran with an empty URL and failed the build, costing a cycle on almost every run, and the generated `launch.sh` hit the same failure when replaying the artifact.

`agent.project_url` is now threaded through `_docker_build_image`, with a matching `--build-arg` in `launch.sh`. Docker only warns about build args a Dockerfile does not declare, so this is a no-op when the URL is hardcoded.

*Observed:* before, `RUN test -n "$REPO_URL" && git clone ...` failed with exit 1 on the first build of most projects; after, the agent reached a running container in cycle 1, and `./launch.sh` reproduced the run's test results exactly (26/26 passing on the project tested).

### 3. Support pinning a project run to a specific commit

Projects could only be built at the default branch HEAD, so a benchmark of (repository, commit) pairs could not be expressed — several entries for the same repository would all resolve to the same code.

Adds an optional `commit` field to `Project`, carried through the run metadata into the agent. When set, the preparation phase clones at full depth and checks out that SHA (a shallow clone cannot reach an arbitrary commit), and the agent prompt states the required commit and shows the clone/checkout pattern so the container is built at the same revision.

With no commit the behaviour is unchanged: shallow clone, no checkout, no extra prompt section, and metadata files written before this change still load.

*Observed:* used to run 60 (repository, commit) pairs across 33 Java repositories; the generated Dockerfiles contained `git checkout --detach $COMMIT_SHA` as a `RUN` step, so a failed checkout fails the build rather than silently falling back to HEAD.

### 4. Add `--knowledge-model` to the launcher, and a `.gitignore`

`launcher.py` had no way to pass `main.py`'s existing `--knowledge-model`, so batch runs always used the default regardless of configuration. Also adds a `.gitignore` for the generated workspace and search caches.

---

Tested by running the full pipeline on ~110 project setups (the paper's 50 plus a 60-pair Java benchmark) with `openrouter/openai/gpt-5-nano`.
